### PR TITLE
Relocate CI job

### DIFF
--- a/.github/workflows/puppet.yaml
+++ b/.github/workflows/puppet.yaml
@@ -16,7 +16,7 @@ jobs:
           submodules: false
       - name: Install dependencies
         run: |
-	  sudo apt-get update
+          sudo apt-get update
           wget https://apt.puppet.com/puppet-release-focal.deb
           sudo dpkg -i puppet-tools-release-focal.deb
           wget https://apt.puppet.com/puppet-tools-release-focal.deb

--- a/.github/workflows/puppet.yaml
+++ b/.github/workflows/puppet.yaml
@@ -18,9 +18,9 @@ jobs:
         run: |
           sudo apt-get update
           wget https://apt.puppet.com/puppet-release-focal.deb
-          sudo dpkg -i puppet-tools-release-focal.deb
+          sudo dpkg -i $PWD/puppet-tools-release-focal.deb
           wget https://apt.puppet.com/puppet-tools-release-focal.deb
-          sudo dpkg -i puppet-tools-release-focal.deb
+          sudo dpkg -i $PWD/puppet-tools-release-focal.deb
           sudo apt-get install -y puppet-agent-7.28.0-1.el9 puppet-bolt
           sudo update-alternatives --install /usr/bin/puppet puppet-agent /opt/puppetlabs/bin/puppet 10
           sudo chmod +t /tmp # workaround ruby need within prep.sh

--- a/.github/workflows/puppet.yaml
+++ b/.github/workflows/puppet.yaml
@@ -6,6 +6,28 @@ on:
       - puppet
 
 jobs:
+  prep:
+    name: Download modules
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+      - name: Install dependencies
+        run: |
+	  sudo apt-get update
+          wget https://apt.puppet.com/puppet-release-focal.deb
+          sudo dpkg -i puppet-tools-release-focal.deb
+          wget https://apt.puppet.com/puppet-tools-release-focal.deb
+          sudo dpkg -i puppet-tools-release-focal.deb
+          sudo apt-get install -y puppet-agent-7.28.0-1.el9 puppet-bolt
+          sudo update-alternatives --install /usr/bin/puppet puppet-agent /opt/puppetlabs/bin/puppet 10
+          sudo chmod +t /tmp # workaround ruby need within prep.sh
+      - name: Prep project
+        run: |
+          ./puppet/prep.sh
+
   puppet-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/puppet.yaml
+++ b/.github/workflows/puppet.yaml
@@ -18,9 +18,9 @@ jobs:
         run: |
           sudo apt-get update
           wget https://apt.puppet.com/puppet-release-focal.deb
-          sudo dpkg -i $PWD/puppet-tools-release-focal.deb
+          sudo dpkg -i puppet-release-focal.deb
           wget https://apt.puppet.com/puppet-tools-release-focal.deb
-          sudo dpkg -i $PWD/puppet-tools-release-focal.deb
+          sudo dpkg -i puppet-tools-release-focal.deb
           sudo apt-get install -y puppet-agent-7.28.0-1.el9 puppet-bolt
           sudo update-alternatives --install /usr/bin/puppet puppet-agent /opt/puppetlabs/bin/puppet 10
           sudo chmod +t /tmp # workaround ruby need within prep.sh

--- a/.github/workflows/puppet.yaml
+++ b/.github/workflows/puppet.yaml
@@ -21,7 +21,7 @@ jobs:
           wget https://apt.puppet.com/puppet-tools-release-focal.deb
           sudo dpkg -i puppet-tools-release-focal.deb
           sudo apt-get update
-          sudo apt-get install -y puppet-agent-7.28.0-1.el9 puppet-bolt
+          sudo apt-get install -y puppet-agent puppet-bolt
           sudo update-alternatives --install /usr/bin/puppet puppet-agent /opt/puppetlabs/bin/puppet 10
           sudo chmod +t /tmp # workaround ruby need within prep.sh
       - name: Prep project

--- a/.github/workflows/puppet.yaml
+++ b/.github/workflows/puppet.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: puppet-lint
         uses: scottbrenner/puppet-lint-action@master
         with:
-          args: puppet/
+          args: puppet/ --fail-on-warnings

--- a/.github/workflows/puppet.yaml
+++ b/.github/workflows/puppet.yaml
@@ -1,0 +1,19 @@
+name: Puppet module
+on:
+  push:
+    paths:
+      - .github/workflows/puppet.yaml
+      - puppet
+
+jobs:
+  puppet-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+      - name: puppet-lint
+        uses: scottbrenner/puppet-lint-action@master
+        with:
+          args: puppet/

--- a/.github/workflows/puppet.yaml
+++ b/.github/workflows/puppet.yaml
@@ -16,11 +16,11 @@ jobs:
           submodules: false
       - name: Install dependencies
         run: |
-          sudo apt-get update
           wget https://apt.puppet.com/puppet-release-focal.deb
           sudo dpkg -i puppet-release-focal.deb
           wget https://apt.puppet.com/puppet-tools-release-focal.deb
           sudo dpkg -i puppet-tools-release-focal.deb
+          sudo apt-get update
           sudo apt-get install -y puppet-agent-7.28.0-1.el9 puppet-bolt
           sudo update-alternatives --install /usr/bin/puppet puppet-agent /opt/puppetlabs/bin/puppet 10
           sudo chmod +t /tmp # workaround ruby need within prep.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ stages:
 .prep-install-python: &prep-install-python |
   dnf install -y python3 python3-pip python3-wheel
   dnf clean all && rm -rf /var/cache/yum
-  pip3 install --upgrade pip pip-tools && ln -s pip3 /usr/bin/pip
+  pip3 install --upgrade pip pip-tools
 
 .prep-install-docker: &prep-install-docker |
   dnf remove -y docker \
@@ -276,22 +276,6 @@ transcoder_unit-test:
       coverage_report:
         coverage_format: cobertura
         path: transcoder/coverage.xml
-
-puppet-lint:
-  stage: test
-  needs: []
-  allow_failure: true
-  rules:
-    - if: $TRY_LATEST_PROMOTE != "true"
-      changes:
-        - ".gitlab-ci.yml"
-        - puppet/**/*
-  before_script:
-    - *prep-install-ca
-    - dnf module install -y ruby:2.7
-    - gem install puppet-lint
-  script:
-    - puppet-lint puppet
 
 # Pull in the latest commits from default submodule branches
 promote:

--- a/puppet/modules/apl_test/manifests/camserver.pp
+++ b/puppet/modules/apl_test/manifests/camserver.pp
@@ -62,23 +62,23 @@ class apl_test::camserver(
 
   class { 'trusted_ca': }
   concat { '/ammos/etc/pki/tls/certs/ammos-ca-bundle.crt':
-    owner  => 'root',
-    group  => 'ammos-tls',
-    mode   => '0444',
+    owner   => 'root',
+    group   => 'ammos-tls',
+    mode    => '0444',
     require => Package[$cam_main_package], # for owner/group
   }
   file { '/ammos/etc/pki/tls/certs/ammos-server-cert.pem':
-    source => $tls_server_cert,
-    owner  => 'cam-srv',
-    group  => 'ammos-tls',
-    mode   => '0444',
+    source  => $tls_server_cert,
+    owner   => 'cam-srv',
+    group   => 'ammos-tls',
+    mode    => '0444',
     require => Package[$cam_main_package], # for owner/group
   }
   file { '/ammos/etc/pki/tls/private/ammos-server-key.pem':
-    source => $tls_server_key,
-    owner  => 'cam-srv',
-    group  => 'ammos-tls',
-    mode   => '0400',
+    source  => $tls_server_key,
+    owner   => 'cam-srv',
+    group   => 'ammos-tls',
+    mode    => '0400',
     require => Package[$cam_main_package], # for owner/group
   }
   openssl::export::pkcs12 { 'ammos-server-keystore':
@@ -121,9 +121,9 @@ class apl_test::camserver(
     }
   }
   file { '/ammos/etc/pki/tls/certs/ammos-truststore.jks':
-    owner   => 'cam-srv',
-    group   => 'ammos-tls',
-    mode    => '0444',
+    owner => 'cam-srv',
+    group => 'ammos-tls',
+    mode  => '0444',
   }
 
   file { '/ammos/cam-server/server':


### PR DESCRIPTION
The switch to RHEL9 broke a GitLab CI job to run `puppet-lint`, but that should be a job in GitHub CI anyway.

Closes #52 