### PR TITLE
Use safe-characters for CI image tag

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
-      DOCKER_IMAGE_TAG: ${CI_COMMIT_REF_SLUG}
+      DOCKER_IMAGE_TAG: ${{ env.CI_COMMIT_REF_SLUG }}
       AUTHNZ_EMU: "1"
       ANMS_COMPOSE_OPTS: "-f docker-compose.yml -p anms"
       AGENT_COMPOSE_OPTS: "-f agent-compose.yml -p agents"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
-      DOCKER_IMAGE_TAG: $CI_COMMIT_REF_SLUG
       AUTHNZ_EMU: "1"
       ANMS_COMPOSE_OPTS: "-f docker-compose.yml -p anms"
       AGENT_COMPOSE_OPTS: "-f agent-compose.yml -p agents"
@@ -26,6 +25,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Tag name env
+        run: |
+          DOCKER_IMAGE_TAG=$(echo ${{ github.head_ref || github.ref_name }} | sed 's/[^a-zA-Z0-9\-\._]/-/g')
+          echo "DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG}" >> $GITHUB_ENV
       - name: Build
         run: |
           ./build.sh buildonly

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
-      DOCKER_IMAGE_TAG: ${{ env.CI_COMMIT_REF_SLUG }}
+      DOCKER_IMAGE_TAG: $CI_COMMIT_REF_SLUG
       AUTHNZ_EMU: "1"
       ANMS_COMPOSE_OPTS: "-f docker-compose.yml -p anms"
       AGENT_COMPOSE_OPTS: "-f agent-compose.yml -p agents"

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
-      DOCKER_IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
+      DOCKER_IMAGE_TAG: ${CI_COMMIT_REF_SLUG}
       AUTHNZ_EMU: "1"
       ANMS_COMPOSE_OPTS: "-f docker-compose.yml -p anms"
       AGENT_COMPOSE_OPTS: "-f agent-compose.yml -p agents"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ variables:
   # for Ruby/bolt
   SSL_CERT_FILE: /etc/pki/tls/certs/ca-bundle.crt
   # Project-specific environment
-  DOCKER_IMAGE_TAG: $CI_COMMIT_REF_NAME
+  DOCKER_IMAGE_TAG: $CI_COMMIT_REF_SLUG
   DOCKER_IMAGE_PREFIX: $DOCKER_REGISTRY/$DOCKER_GROUP/
   AUTHNZ_EMU: 1
   ANMS_COMPOSE_OPTS: -f docker-compose.yml -p anms


### PR DESCRIPTION
Not using this was causing CI failures when branch names contained [invalid tag characters](https://docs.docker.com/reference/cli/docker/image/tag/#description).