### PR TITLE
Fix raw link to user guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If yes, then use this README for:
 * Basic configuration
 * High-level overview
 
-For detailed operational guidance after installation, refer to the ANMS User Guide, found here: www.nasa-ammos.github.io/anms-docs/.
+For detailed operational guidance after installation, refer to the ANMS User Guide, found [here](https://nasa-ammos.github.io/anms-docs/).
 
 **2. Are you an AMMOS user or operating an already-installed ANMS instance (not from source)?**
 


### PR DESCRIPTION
The link to the user guide in the README.md was a raw `www.` style link. Clicking it results leads to a insecure connection warning in the browser because plain http is used.  Changed to be a https:// link