### PR TITLE
Use podman v5 for CI action

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Install Podman
         if: ${{matrix.ctrmgr == 'podman'}}
-        uses: redhat-actions/podman-install@main
+        uses: redhat-actions/podman-install@5bc2ecc87c737059124c295845be51ee7297fb89
       - name: Start Container Service
         if: ${{matrix.ctrmgr == 'podman'}}
         run: systemctl --user start podman.socket

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -24,12 +24,9 @@ jobs:
       AUTHNZ_PORT: 8084
       AUTHNZ_HTTPS_PORT: 8443
     steps:
-      - name: Start Container Service
+      - name: Install Podman
         if: ${{matrix.ctrmgr == 'podman'}}
-        run: |
-          systemctl --user start podman.socket
-          systemctl --user enable podman.socket
-          export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+        uses: redhat-actions/podman-install@main
       - name: Versions
         run: |
           ${DOCKER_CMD} -v

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Install Podman
         if: ${{matrix.ctrmgr == 'podman'}}
         uses: redhat-actions/podman-install@main
+      - name: Start Container Service
+        if: ${{matrix.ctrmgr == 'podman'}}
+        run: systemctl --user start podman.socket
       - name: Versions
         run: |
           ${DOCKER_CMD} -v


### PR DESCRIPTION
The default ubuntu-24.04 image uses podman v4, which doesn't meet the [ANMS minimum](https://nasa-ammos.github.io/anms-docs/product-guide/html/index.html#target-host-packages).