### PR TITLE
Upgrade form Postgres14 to Postgres18

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,13 @@ This file will contain upgrading instructions for all future tagged releases.
 
 # Upgrading v2.0.0 to main
 
+Note: If data preservation in the postgresql database is not required, `podman volume rm anms_postgres-data` is the only step required to start with a clean database.
+
+## Postgresql 14 to 18 upgrade
+
+If you wish to preserve existing data, you should backup the existing DB prior to updating then follow the Postgres upgrade guide. You can access the container with `podman|docker exec postgres bash`
+https://www.postgresql.org/docs/current/pgupgrade.html
+
 ## Grafana DB Update
 A new database named `grafana_internal_db` needs to be created in postgres. 
 

--- a/anms.Containerfile
+++ b/anms.Containerfile
@@ -72,7 +72,7 @@ COPY deps/dtnma-adms /usr/src/dtnma-adms
 
 
 # This is a postgres stateful database with data definition startup SQL scripts
-FROM docker.io/library/postgres:14 AS anms-sql
+FROM docker.io/library/postgres:18 AS anms-sql
 
 # Grafana DB Creation (can't setup second DB via env variable)
 COPY grafana/create_grafana_db.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_NAME}
     volumes:
-      - "postgres-data:/var/lib/postgresql/data"
+      - "postgres-data:/var/lib/postgresql"
     ports:
       - "${DB_PORT-5432}:5432"
 


### PR DESCRIPTION
Note: If you don't care about preserving existing data, this PR requires deleting your postgres volume mount.  To preserve data, additional steps may be necessary to invoke pg_upgrade within the container to migrate data.

This upgrade is in anticipation of Postgres14 reaching EOL later this year.