### PR TITLE
299 Improve automated build test ruff

### DIFF
--- a/.github/workflows/anms-core.yaml
+++ b/.github/workflows/anms-core.yaml
@@ -32,6 +32,36 @@ jobs:
         run: |
           FAIL_SRC=0
           flake8 . || FAIL_SRC=$?
+  ruff:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Set ENV
+        run: ./update_env.sh
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip3 install deps/dtnma-ace
+          pip3 install deps/dtnma-camp
+      - name: Install ruff
+        working-directory: anms-core
+        run: pip3 install -e '.[ruff]'
+      - name: Run ruff check
+        working-directory: anms-core
+        run: |
+          FAIL_SRC=0
+          ruff check . || FAIL_SRC=$?
+      - name: Run ruff format --check
+        working-directory: anms-core
+        run: |
+          FAIL_SRC=0
+          ruff format --check . || FAIL_SRC=$?
   anms-core_integration-test:
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/anms-core.yaml
+++ b/.github/workflows/anms-core.yaml
@@ -10,31 +10,6 @@ on:
     - cron: '0 0 * * 0' # weekly
 
 jobs:
-  flake8:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-      - name: Set ENV
-        run: ./update_env.sh
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          pip3 install deps/dtnma-ace
-          pip3 install deps/dtnma-camp
-      - name: Install flake8
-        working-directory: anms-core
-        run: pip3 install -e '.[flake8]'
-      - name: Run flake8
-        working-directory: anms-core
-        run: |
-          FAIL_SRC=0
-          flake8 . || FAIL_SRC=$?
   ruff:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/anms-core.yaml
+++ b/.github/workflows/anms-core.yaml
@@ -5,6 +5,9 @@ on:
       - .github/workflows/anms-core.yaml
       - deps/**
       - anms-core/**
+  pull_request: {} # any target
+  schedule:
+    - cron: '0 0 * * 0' # weekly
 
 jobs:
   flake8:

--- a/.github/workflows/aricodec.yaml
+++ b/.github/workflows/aricodec.yaml
@@ -31,3 +31,32 @@ jobs:
         run: |
           FAIL_SRC=0
           flake8 . || FAIL_SRC=$?
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Set ENV
+        run: ./update_env.sh
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip3 install deps/dtnma-ace
+      - name: Install ruff
+        working-directory: aricodec
+        run: pip3 install -e '.[ruff]'
+      - name: Run ruff check
+        working-directory: aricodec
+        run: |
+          FAIL_SRC=0
+          ruff check . || FAIL_SRC=$?
+      - name: Run ruff format --check
+        working-directory: aricodec
+        run: |
+          FAIL_SRC=0
+          ruff format --check . || FAIL_SRC=$?

--- a/.github/workflows/aricodec.yaml
+++ b/.github/workflows/aricodec.yaml
@@ -5,6 +5,9 @@ on:
       - .github/workflows/aricodec.yaml
       - deps/**
       - aricodec/**
+  pull_request: {} # any target
+  schedule:
+    - cron: '0 0 * * 0' # weekly
 
 jobs:
   flake8:

--- a/.github/workflows/aricodec.yaml
+++ b/.github/workflows/aricodec.yaml
@@ -10,30 +10,6 @@ on:
     - cron: '0 0 * * 0' # weekly
 
 jobs:
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-      - name: Set ENV
-        run: ./update_env.sh
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          pip3 install deps/dtnma-ace
-      - name: Install flake8
-        working-directory: aricodec
-        run: pip3 install -e '.[flake8]'
-      - name: Run flake8
-        working-directory: aricodec
-        run: |
-          FAIL_SRC=0
-          flake8 . || FAIL_SRC=$?
   ruff:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/transcoder.yaml
+++ b/.github/workflows/transcoder.yaml
@@ -26,3 +26,27 @@ jobs:
         run: |
           FAIL_SRC=0
           flake8 . || FAIL_SRC=$?
+  ruff:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install ruff
+        working-directory: transcoder
+        run: pip3 install -e '.[ruff]'
+      - name: Run ruff check
+        working-directory: transcoder
+        run: |
+          FAIL_SRC=0
+          ruff check . || FAIL_SRC=$?
+      - name: Run ruff format --check
+        working-directory: transcoder
+        run: |
+          FAIL_SRC=0
+          ruff format --check . || FAIL_SRC=$?

--- a/.github/workflows/transcoder.yaml
+++ b/.github/workflows/transcoder.yaml
@@ -10,25 +10,6 @@ on:
     - cron: '0 0 * * 0' # weekly
 
 jobs:
-  flake8:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-      - name: Install flake8
-        working-directory: transcoder
-        run: pip3 install flake8
-      - name: Run flake8
-        working-directory: transcoder
-        run: |
-          FAIL_SRC=0
-          flake8 . || FAIL_SRC=$?
   ruff:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/transcoder.yaml
+++ b/.github/workflows/transcoder.yaml
@@ -5,6 +5,9 @@ on:
       - .github/workflows/transcoder.yaml
       - deps/**
       - transcoder/**
+  pull_request: {} # any target
+  schedule:
+    - cron: '0 0 * * 0' # weekly
 
 jobs:
   flake8:

--- a/anms-core/pyproject.toml
+++ b/anms-core/pyproject.toml
@@ -67,12 +67,21 @@ flake8 = [
   "flake8_pyproject",
   "flake8_formatter_junit_xml",
 ]
+ruff = [
+  "ruff",
+]
 
 [tool.autopep8]
 max_line_length = 160
 
 [tool.flake8]
 max-line-length=160
+
+[tool.ruff]
+line-length = 160
+
+[tool.ruff.lint]
+select = ["E", "W", "F"]
 
 [tool.setuptools]
 include-package-data = true

--- a/anms-core/pyproject.toml
+++ b/anms-core/pyproject.toml
@@ -68,7 +68,7 @@ flake8 = [
   "flake8_formatter_junit_xml",
 ]
 ruff = [
-  "ruff",
+  "ruff==0.15.22",
 ]
 
 [tool.autopep8]

--- a/anms-core/pyproject.toml
+++ b/anms-core/pyproject.toml
@@ -81,7 +81,7 @@ max-line-length=160
 line-length = 160
 
 [tool.ruff.lint]
-select = ["E", "W", "F"]
+select = ["E", "W", "F", "I"]
 
 [tool.setuptools]
 include-package-data = true

--- a/anms-core/pyproject.toml
+++ b/anms-core/pyproject.toml
@@ -62,20 +62,12 @@ test = [
   "mock-alchemy ==0.2.5",
   "coverage ~=6.5.0",
 ]
-flake8 = [
-  "flake8",
-  "flake8_pyproject",
-  "flake8_formatter_junit_xml",
-]
 ruff = [
   "ruff==0.15.22",
 ]
 
 [tool.autopep8]
 max_line_length = 160
-
-[tool.flake8]
-max-line-length=160
 
 [tool.ruff]
 line-length = 160

--- a/anms-ui/CONTRIBUTING.md
+++ b/anms-ui/CONTRIBUTING.md
@@ -57,7 +57,7 @@ subcontract 1658085.
 
 ###### Python Code Style
 * Follow Pep8 with some exclusions as needed.
-* TBD: pylint and flake8 should be enabled in the future to verify this.
+* TBD: pylint and ruff should be enabled in the future to verify this.
 
 ###### Vue Code Style
 * VueJS code should adhere as best as possible to the following style guidelines:

--- a/anms.Containerfile
+++ b/anms.Containerfile
@@ -64,7 +64,7 @@ ENV PYTHON=python3
 ENV PY_WHEEL_DIR=/usr/local/lib/wheels
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    ${PIP} install --upgrade 'pip~=24.0' 'pip-tools~=7.5'
+    ${PIP} install --upgrade 'pip~=24.0' 'pip-tools==7.5.3'
 
 COPY deps/dtnma-ace /usr/src/dtnma-ace
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/aricodec/pyproject.toml
+++ b/aricodec/pyproject.toml
@@ -37,12 +37,21 @@ flake8 = [
   "flake8_pyproject",
   "flake8_formatter_junit_xml",
 ]
+ruff = [
+  "ruff",
+]
 
 [tool.autopep8]
 max_line_length = 160
 
 [tool.flake8]
 max-line-length=160
+
+[tool.ruff]
+line-length = 160
+
+[tool.ruff.lint]
+select = ["E", "W", "F"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/aricodec/pyproject.toml
+++ b/aricodec/pyproject.toml
@@ -38,7 +38,7 @@ flake8 = [
   "flake8_formatter_junit_xml",
 ]
 ruff = [
-  "ruff",
+  "ruff==0.15.22",
 ]
 
 [tool.autopep8]

--- a/aricodec/pyproject.toml
+++ b/aricodec/pyproject.toml
@@ -32,20 +32,12 @@ test = [
   "pytest-cov ~=3.0.0",
   "coverage ~=6.5.0",
 ]
-flake8 = [
-  "flake8",
-  "flake8_pyproject",
-  "flake8_formatter_junit_xml",
-]
 ruff = [
   "ruff==0.15.22",
 ]
 
 [tool.autopep8]
 max_line_length = 160
-
-[tool.flake8]
-max-line-length=160
 
 [tool.ruff]
 line-length = 160

--- a/aricodec/pyproject.toml
+++ b/aricodec/pyproject.toml
@@ -51,7 +51,7 @@ max-line-length=160
 line-length = 160
 
 [tool.ruff.lint]
-select = ["E", "W", "F"]
+select = ["E", "W", "F", "I"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/transcoder/pyproject.toml
+++ b/transcoder/pyproject.toml
@@ -36,7 +36,7 @@ flake8 = [
   "flake8_formatter_junit_xml",
 ]
 ruff = [
-  "ruff",
+  "ruff==0.15.22",
 ]
 
 [tool.autopep8]

--- a/transcoder/pyproject.toml
+++ b/transcoder/pyproject.toml
@@ -35,12 +35,21 @@ flake8 = [
   "flake8_pyproject",
   "flake8_formatter_junit_xml",
 ]
+ruff = [
+  "ruff",
+]
 
 [tool.autopep8]
 max_line_length = 160
 
 [tool.flake8]
 max-line-length=160
+
+[tool.ruff]
+line-length = 160
+
+[tool.ruff.lint]
+select = ["E", "W", "F"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/transcoder/pyproject.toml
+++ b/transcoder/pyproject.toml
@@ -49,7 +49,7 @@ max-line-length=160
 line-length = 160
 
 [tool.ruff.lint]
-select = ["E", "W", "F"]
+select = ["E", "W", "F", "I"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/transcoder/pyproject.toml
+++ b/transcoder/pyproject.toml
@@ -30,20 +30,12 @@ test = [
   "pytest-cov ~=3.0.0",
   "coverage ~=6.5.0",
 ]
-flake8 = [
-  "flake8",
-  "flake8_pyproject",
-  "flake8_formatter_junit_xml",
-]
 ruff = [
   "ruff==0.15.22",
 ]
 
 [tool.autopep8]
 max_line_length = 160
-
-[tool.flake8]
-max-line-length=160
 
 [tool.ruff]
 line-length = 160


### PR DESCRIPTION
Address this comment in #299 about adding ruff to the CI: https://github.com/NASA-AMMOS/anms/issues/299#issuecomment-5007333730. The `ruff` version has been pinned to version `0.15.22` as it is the latest release with many minor version updates, and the new version `0.16.0` is fresh and has some potentially breaking changes, albeit that wouldn't impact the success of the CI job: https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#0160